### PR TITLE
Align AVL and IO element decoding with Teltonika specifications

### DIFF
--- a/ioelements/ioelements.go
+++ b/ioelements/ioelements.go
@@ -10,6 +10,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"strings"
 )
 
 type ElementType uint8
@@ -48,7 +49,23 @@ type Decoder struct {
 
 var defaultDecoder = &Decoder{ioElementDefinitions, supportedModels}
 
+// Teltonika documents sensor status values as raw integers before scaling.
+var sensorStatusCodes = map[int64]string{
+	850:   "Sensor not ready",
+	2000:  "Value read error",
+	3000:  "Not connected",
+	4000:  "ID failed",
+	5000:  "Sensor not ready",
+	32767: "Sensor not found",
+	32766: "Failed sensor data parsing",
+	32765: "Abnormal sensor state",
+	32764: "Abnormal sensor state",
+}
+
 func (r *IOElement) String() string {
+	if r.Definition == nil {
+		return fmt.Sprintf("IO %d: %v", r.Id, r.Value)
+	}
 	switch r.Value.(type) {
 	case float64:
 		return fmt.Sprintf("%s: %.3f%s", r.Definition.Name, r.Value, r.Definition.Units)
@@ -73,86 +90,212 @@ func DefaultDecoder() *Decoder {
 	return defaultDecoder
 }
 
-// GetElementInfo returns full description of I/O Element by its id and model name
-// If you don't know the model name, you can skip the model name check by passing '*' as the model name
-func (r *Decoder) GetElementInfo(modelName string, id uint16) (*IOElementDefinition, error) {
+func definitionSupportsModel(def *IOElementDefinition, modelName string) bool {
+	for _, model := range def.SupportedModels {
+		if model == modelName {
+			return true
+		}
+	}
+	return false
+}
+
+func isVariableLengthType(t ElementType) bool {
+	return t == IOElementHEX || t == IOElementASCII
+}
+
+func definitionMatchesWireSize(def *IOElementDefinition, wireSize int) bool {
+	if wireSize <= 0 {
+		return false
+	}
+	if isVariableLengthType(def.Type) {
+		if def.NumBytes <= 0 {
+			return true
+		}
+		return def.NumBytes == wireSize
+	}
+	if def.NumBytes > 0 {
+		return def.NumBytes == wireSize
+	}
+	return wireSize == 1 || wireSize == 2 || wireSize == 4 || wireSize == 8
+}
+
+func (r *Decoder) selectDefinition(modelName string, id uint16, wireSize int) (*IOElementDefinition, error) {
 	if modelName != "*" && !r.supportedModels[modelName] {
 		return nil, fmt.Errorf("model '%s' is not supported", modelName)
 	}
 
-	for _, e := range r.definitions {
-		if e.Id != id {
+	var modelFallback *IOElementDefinition
+	var wildcardSizeMatch *IOElementDefinition
+	var wildcardFallback *IOElementDefinition
+
+	for i := range r.definitions {
+		def := &r.definitions[i]
+		if def.Id != id {
 			continue
 		}
-		if modelName == "*" {
-			return &e, nil
-		}
 
-		for _, v := range e.SupportedModels {
-			if v != modelName {
+		if modelName != "*" {
+			if !definitionSupportsModel(def, modelName) {
 				continue
 			}
-			return &e, nil
+			if wireSize > 0 && definitionMatchesWireSize(def, wireSize) {
+				return def, nil
+			}
+			if modelFallback == nil {
+				modelFallback = def
+			}
+			continue
+		}
+
+		if wireSize > 0 && definitionMatchesWireSize(def, wireSize) {
+			if wildcardSizeMatch == nil {
+				wildcardSizeMatch = def
+			}
+			continue
+		}
+		if wildcardFallback == nil {
+			wildcardFallback = def
 		}
 	}
 
+	if modelName != "*" {
+		if modelFallback != nil {
+			return modelFallback, nil
+		}
+		return nil, fmt.Errorf("element with id %v not found for model '%s'", id, modelName)
+	}
+	if wildcardSizeMatch != nil {
+		return wildcardSizeMatch, nil
+	}
+	if wildcardFallback != nil {
+		return wildcardFallback, nil
+	}
 	return nil, fmt.Errorf("element with id %v not found", id)
 }
 
-// Decode decodes an I/O Element by model name and id (result can be represented in numan-readable format)
-// If you don't know the model name, you can skip the model name check by passing '*' as the model name
+// GetElementInfo returns full description of I/O Element by its id and model name.
+// If you don't know the model name, you can skip the model name check by passing '*' as the model name.
+// When multiple definitions share an IO ID, pass the expected on-wire byte length via GetElementInfoWithSize.
+func (r *Decoder) GetElementInfo(modelName string, id uint16) (*IOElementDefinition, error) {
+	return r.selectDefinition(modelName, id, 0)
+}
+
+// GetElementInfoWithSize returns the I/O Element definition that best matches the on-wire byte length.
+func (r *Decoder) GetElementInfoWithSize(modelName string, id uint16, wireSize int) (*IOElementDefinition, error) {
+	return r.selectDefinition(modelName, id, wireSize)
+}
+
+// Decode decodes an I/O Element by model name and id (result can be represented in human-readable format).
+// Wire byte length is used to disambiguate IO IDs that map to multiple catalog entries.
 func (r *Decoder) Decode(modelName string, id uint16, buffer []byte) (*IOElement, error) {
-	def, err := r.GetElementInfo(modelName, id)
+	def, err := r.selectDefinition(modelName, id, len(buffer))
 	if err != nil {
 		return nil, err
 	}
 	return r.DecodeByDefinition(def, buffer)
 }
 
-// DecodeByDefinition decodes an I/O Element according to a given definition
+func decodeNumericUnsigned(buffer []byte) uint64 {
+	switch len(buffer) {
+	case 1:
+		return uint64(buffer[0])
+	case 2:
+		return uint64(binary.BigEndian.Uint16(buffer))
+	case 4:
+		return uint64(binary.BigEndian.Uint32(buffer))
+	default:
+		return binary.BigEndian.Uint64(buffer)
+	}
+}
+
+func decodeNumericSigned(buffer []byte) int64 {
+	switch len(buffer) {
+	case 1:
+		return int64(int8(buffer[0]))
+	case 2:
+		return int64(int16(binary.BigEndian.Uint16(buffer)))
+	case 4:
+		return int64(int32(binary.BigEndian.Uint32(buffer)))
+	default:
+		return int64(binary.BigEndian.Uint64(buffer))
+	}
+}
+
+func definitionUsesSensorStatusCodes(def *IOElementDefinition) bool {
+	if strings.Contains(def.Name, "Temperature") {
+		return true
+	}
+	desc := def.Description
+	return strings.Contains(desc, "850") ||
+		strings.Contains(desc, "3000") ||
+		strings.Contains(desc, "32767")
+}
+
+func interpretSensorStatus(def *IOElementDefinition, raw int64) (interface{}, bool) {
+	if !definitionUsesSensorStatusCodes(def) {
+		return nil, false
+	}
+	if msg, ok := sensorStatusCodes[raw]; ok {
+		return msg, true
+	}
+	return nil, false
+}
+
+func isBooleanDefinition(def *IOElementDefinition, wireSize int) bool {
+	return wireSize == 1 &&
+		def.NumBytes == 1 &&
+		def.Type == IOElementUnsigned &&
+		def.Min == 0 &&
+		def.Max == 1
+}
+
+// DecodeByDefinition decodes an I/O Element according to a given definition.
+// Numeric decoding uses the on-wire byte length from the AVL packet.
 func (r *Decoder) DecodeByDefinition(def *IOElementDefinition, buffer []byte) (*IOElement, error) {
+	if len(buffer) == 0 {
+		return nil, fmt.Errorf("unable to decode io element with id %v: empty buffer", def.Id)
+	}
+
 	var res interface{}
 
-	size := len(buffer)
-	if size == 1 && def.Min == 0 && def.Max == 1 && def.Type == IOElementUnsigned {
-		res = buffer[0] == 1
-	} else if (size == 1 || size == 2 || size == 4 || size == 8) && (def.Type == IOElementUnsigned || def.Type == IOElementSigned) {
+	switch def.Type {
+	case IOElementUnsigned, IOElementSigned:
+		if isBooleanDefinition(def, len(buffer)) {
+			res = buffer[0] == 1
+			break
+		}
+
+		size := len(buffer)
+		if size != 1 && size != 2 && size != 4 && size != 8 {
+			return nil, fmt.Errorf("unsupported numeric io element size %d for id %v", size, def.Id)
+		}
+
 		if def.Type == IOElementUnsigned {
-			var v uint64
-			if size == 1 {
-				v = uint64(buffer[0])
-			} else if size == 2 {
-				v = uint64(binary.BigEndian.Uint16(buffer))
-			} else if size == 4 {
-				v = uint64(binary.BigEndian.Uint32(buffer))
-			} else {
-				v = binary.BigEndian.Uint64(buffer)
+			raw := int64(decodeNumericUnsigned(buffer))
+			if status, ok := interpretSensorStatus(def, raw); ok {
+				res = status
+				break
 			}
 			if def.Multiplier != 1.0 {
-				res = float64(v) * def.Multiplier
+				res = float64(raw) * def.Multiplier
 			} else {
-				res = v
+				res = raw
 			}
-		} else if def.Type == IOElementSigned {
-			var v int64
-			if size == 1 {
-				v = int64(int8(buffer[0]))
-			} else if size == 2 {
-				v = int64(int16(binary.BigEndian.Uint16(buffer)))
-			} else if size == 4 {
-				v = int64(int32(binary.BigEndian.Uint32(buffer)))
-			} else {
-				v = int64(binary.BigEndian.Uint64(buffer))
+		} else {
+			raw := decodeNumericSigned(buffer)
+			if status, ok := interpretSensorStatus(def, raw); ok {
+				res = status
+				break
 			}
 			if def.Multiplier != 1.0 {
-				res = float64(v) * def.Multiplier
+				res = float64(raw) * def.Multiplier
 			} else {
-				res = v
+				res = raw
 			}
 		}
-	} else if def.Type == IOElementHEX {
+	case IOElementHEX:
 		res = hex.EncodeToString(buffer)
-	} else if def.Type == IOElementASCII {
+	case IOElementASCII:
 		res = string(buffer)
 	}
 

--- a/ioelements/ioelements_test.go
+++ b/ioelements/ioelements_test.go
@@ -1,0 +1,102 @@
+// Copyright 2022-2024 Alim Zanibekov
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+package ioelements
+
+import (
+	"testing"
+)
+
+func TestDecodeIgnitionBoolean(t *testing.T) {
+	dec := DefaultDecoder()
+	el, err := dec.Decode("FMB920", 239, []byte{1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if el.Value != true {
+		t.Fatalf("expected true ignition, got %v", el.Value)
+	}
+}
+
+func TestDecodeTotalOdometer(t *testing.T) {
+	dec := DefaultDecoder()
+	el, err := dec.Decode("FMB920", 16, []byte{0x01, 0x5E, 0x2C, 0x88})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if el.Value.(int64) != 22949000 {
+		t.Fatalf("expected 22949000, got %v", el.Value)
+	}
+}
+
+func TestDecodeAxisXWithSizeDisambiguation(t *testing.T) {
+	dec := DefaultDecoder()
+	el, err := dec.Decode("FMB920", 17, []byte{0x00, 0x1D})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if el.Definition.Name != "Axis X" {
+		t.Fatalf("expected Axis X, got %q", el.Definition.Name)
+	}
+	if el.Value != int64(29) {
+		t.Fatalf("expected 29, got %v", el.Value)
+	}
+}
+
+func TestWildcardLookupPrefersWireSize(t *testing.T) {
+	dec := DefaultDecoder()
+
+	def8, err := dec.GetElementInfoWithSize("*", 8, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if def8.Name != "Authorized iButton" {
+		t.Fatalf("expected 8-byte definition, got %q", def8.Name)
+	}
+
+	def2, err := dec.GetElementInfoWithSize("*", 8, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if def2.Name != "Dallas Temperature 6" {
+		t.Fatalf("expected 2-byte definition, got %q", def2.Name)
+	}
+}
+
+func TestDecodeDallasTemperatureErrorCode(t *testing.T) {
+	dec := DefaultDecoder()
+	el, err := dec.Decode("FMB640", 6, []byte{0x03, 0x52}) // 850
+	if err != nil {
+		t.Fatal(err)
+	}
+	if el.Value != "Sensor not ready" {
+		t.Fatalf("expected sensor status string, got %v", el.Value)
+	}
+}
+
+func TestDecodeNXHexElement(t *testing.T) {
+	dec := DefaultDecoder()
+	payload := []byte{0x11, 0x21, 0x31, 0x02, 0x03, 0x04}
+	el, err := dec.Decode("*", 385, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if el.Value != "112131020304" {
+		t.Fatalf("unexpected hex value %v", el.Value)
+	}
+}
+
+func TestDecodeAnalogInput(t *testing.T) {
+	dec := DefaultDecoder()
+	el, err := dec.Decode("FMB920", 9, []byte{0x00, 0x2B})
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, ok := el.Value.(float64)
+	if !ok || v < 0.042999 || v > 0.043001 {
+		t.Fatalf("expected ~0.043, got %v", el.Value)
+	}
+}

--- a/teltonika.go
+++ b/teltonika.go
@@ -654,18 +654,19 @@ func decodeElementsCodec8(reader *byteReader, data *Data) error {
 
 	data.GenerationType = Unknown
 	data.EventID = uint16(eventId)
-	data.Elements = make([]IOElement, ioCount)
 
 	var n uint8
 	var id uint8
 	var value []byte
-	var k = 0
+	var groupSum uint8
+	elements := make([]IOElement, 0, ioCount)
 
 	for i := 1; i <= 8; i *= 2 {
 		n, err = reader.ReadUInt8BE()
 		if err != nil {
 			return err
 		}
+		groupSum += n
 		for j := 0; j < int(n); j++ {
 			id, err = reader.ReadUInt8BE()
 			if err != nil {
@@ -675,17 +676,24 @@ func decodeElementsCodec8(reader *byteReader, data *Data) error {
 			if err != nil {
 				return err
 			}
-			if k >= int(ioCount) {
-				return fmt.Errorf("too many i/o elements, expected at most %d, found %d", ioCount, k)
+			if len(elements) >= int(ioCount) {
+				return fmt.Errorf("too many i/o elements, expected at most %d", ioCount)
 			}
-			data.Elements[k] = IOElement{
+			elements = append(elements, IOElement{
 				Id:    uint16(id),
 				Value: value,
-			}
-			k++
+			})
 		}
 	}
 
+	if groupSum != ioCount {
+		return fmt.Errorf("IO count mismatch: declared %d, fixed groups contain %d (N1+N2+N4+N8)", ioCount, groupSum)
+	}
+	if len(elements) != int(ioCount) {
+		return fmt.Errorf("IO count mismatch: declared %d, decoded %d", ioCount, len(elements))
+	}
+
+	data.Elements = elements
 	return nil
 }
 
@@ -711,18 +719,19 @@ func decodeElementsCodec16(reader *byteReader, data *Data) error {
 
 	data.GenerationType = GenerationType(generationType)
 	data.EventID = eventId
-	data.Elements = make([]IOElement, ioCount)
 
 	var n uint8
 	var id uint16
 	var value []byte
-	var k = 0
+	var groupSum uint8
+	elements := make([]IOElement, 0, ioCount)
 
 	for i := 1; i <= 8; i *= 2 {
 		n, err = reader.ReadUInt8BE()
 		if err != nil {
 			return err
 		}
+		groupSum += n
 		for j := 0; j < int(n); j++ {
 			id, err = reader.ReadUInt16BE()
 			if err != nil {
@@ -732,17 +741,24 @@ func decodeElementsCodec16(reader *byteReader, data *Data) error {
 			if err != nil {
 				return err
 			}
-			if k >= int(ioCount) {
-				return fmt.Errorf("too many i/o elements, expected at most %d, found %d", ioCount, k)
+			if len(elements) >= int(ioCount) {
+				return fmt.Errorf("too many i/o elements, expected at most %d", ioCount)
 			}
-			data.Elements[k] = IOElement{
+			elements = append(elements, IOElement{
 				Id:    id,
 				Value: value,
-			}
-			k++
+			})
 		}
 	}
 
+	if groupSum != ioCount {
+		return fmt.Errorf("IO count mismatch: declared %d, fixed groups contain %d (N1+N2+N4+N8)", ioCount, groupSum)
+	}
+	if len(elements) != int(ioCount) {
+		return fmt.Errorf("IO count mismatch: declared %d, decoded %d", ioCount, len(elements))
+	}
+
+	data.Elements = elements
 	return nil
 }
 
@@ -759,18 +775,19 @@ func decodeElementsCodec8E(reader *byteReader, data *Data) error {
 
 	data.GenerationType = Unknown
 	data.EventID = eventId
-	data.Elements = make([]IOElement, ioCount)
 
 	var n uint16
 	var id uint16
 	var value []byte
-	var k = 0
+	var groupSum uint16
+	elements := make([]IOElement, 0, ioCount)
 
 	for i := 1; i <= 8; i *= 2 {
 		n, err = reader.ReadUInt16BE()
 		if err != nil {
 			return err
 		}
+		groupSum += n
 		for j := 0; j < int(n); j++ {
 			id, err = reader.ReadUInt16BE()
 			if err != nil {
@@ -780,14 +797,13 @@ func decodeElementsCodec8E(reader *byteReader, data *Data) error {
 			if err != nil {
 				return err
 			}
-			if k >= int(ioCount) {
-				return fmt.Errorf("too many i/o elements, expected at most %d, found %d", ioCount, k)
+			if len(elements) >= int(ioCount) {
+				return fmt.Errorf("too many i/o elements, expected at most %d", ioCount)
 			}
-			data.Elements[k] = IOElement{
+			elements = append(elements, IOElement{
 				Id:    id,
 				Value: value,
-			}
-			k++
+			})
 		}
 	}
 
@@ -808,20 +824,30 @@ func decodeElementsCodec8E(reader *byteReader, data *Data) error {
 		if err != nil {
 			return err
 		}
+		if length == 0 {
+			return fmt.Errorf("NX IO element %d has zero length", i)
+		}
 		value, err = reader.ReadBytes(int(length))
 		if err != nil {
 			return err
 		}
-		if k >= int(ioCount) {
-			return fmt.Errorf("too many i/o elements, expected at most %d, found %d", ioCount, i)
+		if len(elements) >= int(ioCount) {
+			return fmt.Errorf("too many i/o elements, expected at most %d", ioCount)
 		}
-		data.Elements[k] = IOElement{
+		elements = append(elements, IOElement{
 			Id:    id,
 			Value: value,
-		}
-		k++
+		})
 	}
 
+	if int(groupSum)+int(ioCountNX) != int(ioCount) {
+		return fmt.Errorf("IO count mismatch: declared %d, fixed groups contain %d and NX contains %d", ioCount, groupSum, ioCountNX)
+	}
+	if len(elements) != int(ioCount) {
+		return fmt.Errorf("IO count mismatch: declared %d, decoded %d", ioCount, len(elements))
+	}
+
+	data.Elements = elements
 	return nil
 }
 


### PR DESCRIPTION
## Summary

This PR improves binary AVL decoding and IO element semantic decoding to match [Teltonika AVL protocol documentation](https://wiki.teltonika-gps.com/view/Teltonika_AVL_Protocols) and per-parameter catalog semantics.

**AVL codec (`teltonika.go`)**
- Validate that fixed-size IO group counts (`N1+N2+N4+N8`) match the declared total for Codec 8 and Codec 16
- For Codec 8 Extended, validate `fixed groups + NX == declared total`
- Reject zero-length NX payloads
- Build the `Elements` slice with append/validation instead of pre-allocated zero-ID padding

**IO semantics (`ioelements/ioelements.go`)**
- Add `GetElementInfoWithSize(model, id, wireBytes)` to disambiguate IO IDs that appear multiple times in the catalog
- Prefer definitions matching on-wire byte length in `Decode` and `"*"` fallback lookups
- Decode numerics using AVL wire length; restrict boolean interpretation to 1-byte 0/1 parameters
- Interpret documented sensor status codes (e.g. Dallas/BLE temperature 850, 2000, 3000, 32767) before applying multipliers
- Handle variable-length HEX/ASCII (NX) payloads correctly

**Tests**
- Add `ioelements/ioelements_test.go` covering ignition boolean, odometer, axis disambiguation, wildcard size lookup, Dallas error codes, NX HEX, and analog scaling

## Test plan

- [x] `go test . ./ioelements/`
- [x] Existing TCP/UDP codec test vectors (including official wiki hex examples and Codec 8E packets with NX elements) pass unchanged


Made with [Cursor](https://cursor.com)